### PR TITLE
Add pull request validator action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build_matrix:
+    strategy:
+      matrix:
+        dotnet-version: ["7.0.x"]
+        os: ["ubuntu-latest", "windows-latest"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
Adds a github action that validates each pull request by building the project in both linux and windows environments.

Note that the action does not use the build scripts in the repo. Instead it relies on native GitHub action steps that handle installing cached versions of the dotnet SDK and then runs the dotnet build command for the project.